### PR TITLE
Samplecount

### DIFF
--- a/DSView/pv/config/appconfig.cpp
+++ b/DSView/pv/config/appconfig.cpp
@@ -124,6 +124,7 @@ static void _loadApp(AppOptions &o, QSettings &st)
     getFiled("fontSize", st, o.fontSize, 9.0);
     getFiled("autoScrollLatestData", st, o.autoScrollLatestData, true);
     getFiled("version", st, o.version, 1);
+    getFiled("rulerTimeUnits", st, o.rulerTimeUnits, "Time");
 
     o.warnofMultiTrig = true;
 
@@ -161,6 +162,8 @@ static void _saveApp(AppOptions &o, QSettings &st)
     setFiled("fontSize", st, o.fontSize);
     setFiled("autoScrollLatestData", st, o.autoScrollLatestData);
     setFiled("version", st, APP_CONFIG_VERSION);
+    setFiled("rulerTimeUnits", st, o.rulerTimeUnits);
+
 
     QString fmt =  FormatArrayToString(o.m_protocolFormats);
     setFiled("protocalFormats", st, fmt);

--- a/DSView/pv/config/appconfig.h
+++ b/DSView/pv/config/appconfig.h
@@ -34,7 +34,10 @@
 #define THEME_STYLE_LIGHT  "light"
 
 #define APP_NAME  "DSView"
-  
+
+#define RULER_UNIT_SAMPLES "Samples"
+#define RULER_UNIT_TIME    "Time"
+
 //--------------------api---
 QString GetIconPath();
 QString GetAppDataDir();
@@ -72,6 +75,7 @@ struct AppOptions
     bool  swapBackBufferAlways;
     bool  autoScrollLatestData;
     float fontSize;
+    QString rulerTimeUnits;
 
     std::vector<StringPair> m_protocolFormats;
 };

--- a/DSView/pv/dialogs/applicationpardlg.cpp
+++ b/DSView/pv/dialogs/applicationpardlg.cpp
@@ -104,6 +104,18 @@ void ApplicationParamDlg::bind_font_size_list(QComboBox *box, float size)
     box->setCurrentIndex(selDex);
 }
 
+void ApplicationParamDlg::bind_ruler_time_unit(QComboBox *box, QString v)
+{
+    box->addItem(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_TIME), "Time"), RULER_UNIT_TIME);
+    box->addItem(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_SAMPLES), "Samples"), RULER_UNIT_SAMPLES);
+    for(int i=0; i<box->count(); i++) {
+        if(box->itemData(i).toString() == v) {
+            box->setCurrentIndex(i);
+            break;
+        }
+    }
+}
+
 bool ApplicationParamDlg::ShowDlg(QWidget *parent)
 {
     DSDialog dlg(parent, true, true);
@@ -136,6 +148,8 @@ bool ApplicationParamDlg::ShowDlg(QWidget *parent)
     ftCbSize->setFixedWidth(50);
     bind_font_size_list(ftCbSize, app.appOptions.fontSize);
    
+    QComboBox *unitsCb = new DsComboBox();
+    bind_ruler_time_unit(unitsCb, app.appOptions.rulerTimeUnits);
     // Logic group
     QGroupBox *logicGroup = new QGroupBox(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_GROUP_LOGIC), "Logic"));
     QGridLayout *logicLay = new QGridLayout();
@@ -148,6 +162,8 @@ bool ApplicationParamDlg::ShowDlg(QWidget *parent)
     logicLay->addWidget(ck_abortData, 1, 1, Qt::AlignRight);
     logicLay->addWidget(new QLabel(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_AUTO_SCROLL_LATEAST_DATA), "Auto scoll latest")), 2, 0, Qt::AlignLeft); 
     logicLay->addWidget(ck_autoScrollLatestData, 2, 1, Qt::AlignRight);
+    logicLay->addWidget(new QLabel(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_RULER_UNITS), "Ruler / Cursor units")), 3, 0, Qt::AlignLeft);
+    logicLay->addWidget(unitsCb, 3, 1, Qt::AlignRight);
     lay->addWidget(logicGroup);
 
     //Scope group
@@ -205,6 +221,10 @@ bool ApplicationParamDlg::ShowDlg(QWidget *parent)
         }
         if (app.appOptions.autoScrollLatestData != ck_autoScrollLatestData->isChecked()){
             app.appOptions.autoScrollLatestData = ck_autoScrollLatestData->isChecked();
+            bAppChanged = true;
+        }
+        if (app.appOptions.rulerTimeUnits != unitsCb->currentData().toString()) {
+            app.appOptions.rulerTimeUnits = unitsCb->currentData().toString();
             bAppChanged = true;
         }
  

--- a/DSView/pv/dialogs/applicationpardlg.h
+++ b/DSView/pv/dialogs/applicationpardlg.h
@@ -55,6 +55,8 @@ namespace pv
 
         void bind_font_size_list(QComboBox *box, float size);
 
+        void bind_ruler_time_unit(QComboBox* box, QString v);
+
     private:
         QStringList _font_name_list; 
     };

--- a/DSView/pv/dock/measuredock.cpp
+++ b/DSView/pv/dock/measuredock.cpp
@@ -68,11 +68,13 @@ MeasureDock::MeasureDock(QWidget *parent, View &view, SigSession *session) :
     _period_label = new QLabel(_widget);
     _freq_label = new QLabel(_widget);
     _duty_label = new QLabel(_widget);
+    _samples_label = new QLabel(_widget);
 
     _w_label = new QLabel(_widget);
     _p_label = new QLabel(_widget);
     _f_label = new QLabel(_widget);
     _d_label = new QLabel(_widget);
+    _s_label = new QLabel(_widget);
 
     QGridLayout *mouse_layout = new QGridLayout();
     mouse_layout->setVerticalSpacing(5);
@@ -88,6 +90,9 @@ MeasureDock::MeasureDock(QWidget *parent, View &view, SigSession *session) :
     mouse_layout->addWidget(_f_label, 2, 3);
     mouse_layout->addWidget(_freq_label, 2, 4);    
  
+    mouse_layout->addWidget(_s_label, 3, 0);
+    mouse_layout->addWidget(_samples_label, 3, 1);
+
     _mouse_groupBox->setLayout(mouse_layout);
     mouse_layout->setContentsMargins(5, 15, 5, 5);
 
@@ -188,6 +193,7 @@ void MeasureDock::retranslateUi()
     _p_label->setText("P:");
     _f_label->setText("F:");
     _d_label->setText("D:");
+    _s_label->setText("S:");
 }
 
 void MeasureDock::reStyle()
@@ -241,6 +247,7 @@ void MeasureDock::measure_updated()
     _period_label->setText(_view.get_measure("period"));
     _freq_label->setText(_view.get_measure("frequency"));
     _duty_label->setText(_view.get_measure("duty"));
+    _samples_label->setText(_view.get_measure("samples"));
     adjusLabelSize();
 }
 
@@ -979,6 +986,7 @@ void MeasureDock::adjust_form_size(QWidget *wid)
     _period_label->setFixedWidth(mouse_info_label_width);
     _freq_label->setFixedWidth(mouse_info_label_width);
     _duty_label->setFixedWidth(mouse_info_label_width);
+    _samples_label->setFixedWidth(mouse_info_label_width);
    
     auto groups = wid->findChildren<QGroupBox*>();
     for(auto o : groups)

--- a/DSView/pv/dock/measuredock.h
+++ b/DSView/pv/dock/measuredock.h
@@ -150,6 +150,7 @@ private:
     QLabel *_period_label;
     QLabel *_freq_label;
     QLabel *_duty_label;
+    QLabel *_samples_label;
     QLabel *_add_dec_label;
     QGridLayout *_dist_layout;
     QGroupBox *_dist_groupBox;
@@ -173,6 +174,7 @@ private:
     QLabel *_p_label;
     QLabel *_f_label;
     QLabel *_d_label;
+    QLabel *_s_label;
     bool    _bSetting;
 };
 

--- a/DSView/pv/view/cursor.cpp
+++ b/DSView/pv/view/cursor.cpp
@@ -80,12 +80,12 @@ QRect Cursor::get_close_rect(const QRect &rect)
 }
 
 void Cursor::paint_label(QPainter &p, const QRect &rect,
-            unsigned int prefix, bool has_hoff)
+            unsigned int prefix, bool has_hoff, bool show_samples)
 {
     using pv::view::Ruler;
     bool visible;
 
-    compute_text_size(p, prefix);
+    compute_text_size(p, prefix, show_samples);
     const QRect r(get_label_rect(rect, visible, has_hoff));
     if (!visible)
         return;
@@ -119,19 +119,20 @@ void Cursor::paint_label(QPainter &p, const QRect &rect,
     p.drawLine(close.left() + 2, close.bottom() - 2, close.right() - 2, close.top() + 2);
 
 	p.drawText(r, Qt::AlignCenter | Qt::AlignVCenter,
-        Ruler::format_real_time(_index, _view.session().cur_snap_samplerate()));
+        show_samples ? Ruler::format_samples(_index)
+                     : Ruler::format_real_time(_index, _view.session().cur_snap_samplerate()));
 
     const QRect arrowRect = QRect(r.bottomLeft().x(), r.bottomLeft().y(), r.width(), ArrowSize);
     p.drawText(arrowRect, Qt::AlignCenter | Qt::AlignVCenter, QString::number(_order));
 }
 
 void Cursor::paint_fix_label(QPainter &p, const QRect &rect,
-    unsigned int prefix, QChar label, QColor color, bool has_hoff)
+    unsigned int prefix, QChar label, QColor color, bool has_hoff, bool show_samples)
 {
     using pv::view::Ruler;
     bool visible;
 
-    compute_text_size(p, prefix);
+    compute_text_size(p, prefix, show_samples);
     const QRect r(get_label_rect(rect, visible, has_hoff));
     if (!visible)
         return;
@@ -150,17 +151,19 @@ void Cursor::paint_fix_label(QPainter &p, const QRect &rect,
     p.setPen(Qt::white);
     if (has_hoff)
         p.drawText(r, Qt::AlignCenter | Qt::AlignVCenter,
-            Ruler::format_real_time(_index, _view.session().cur_snap_samplerate()));
+            show_samples ? Ruler::format_samples(_index)
+                         : Ruler::format_real_time(_index, _view.session().cur_snap_samplerate()));
 
     const QRect arrowRect = QRect(r.bottomLeft().x(), r.bottomLeft().y(), r.width(), ArrowSize);
     p.drawText(arrowRect, Qt::AlignCenter | Qt::AlignVCenter, label);
 }
 
-void Cursor::compute_text_size(QPainter &p, unsigned int prefix)
+void Cursor::compute_text_size(QPainter &p, unsigned int prefix, bool show_samples)
 {
     (void)prefix;
     _text_size = p.boundingRect(QRect(), 0,
-        Ruler::format_real_time(_index, _view.session().cur_snap_samplerate())).size();
+        show_samples ? Ruler::format_samples(_index)
+                     : Ruler::format_real_time(_index, _view.session().cur_snap_samplerate())).size();
 }
  
 } // namespace view

--- a/DSView/pv/view/cursor.h
+++ b/DSView/pv/view/cursor.h
@@ -75,10 +75,10 @@ public:
 	 * @param prefix The index of the SI prefix to use.
 	 */
     void paint_label(QPainter &p, const QRect &rect,
-        unsigned int prefix, bool has_hoff);
+        unsigned int prefix, bool has_hoff, bool show_samples);
 
     void paint_fix_label(QPainter &p, const QRect &rect,
-        unsigned int prefix, QChar label, QColor color, bool has_hoff);
+        unsigned int prefix, QChar label, QColor color, bool has_hoff, bool show_samples);
 
 public: 
 	inline uint64_t get_key(){
@@ -90,7 +90,7 @@ public:
 	}
 
 private:
-	void compute_text_size(QPainter &p, unsigned int prefix);
+	void compute_text_size(QPainter &p, unsigned int prefix, bool show_samples);
 
 private:
 	QSizeF 		_text_size;

--- a/DSView/pv/view/ruler.cpp
+++ b/DSView/pv/view/ruler.cpp
@@ -202,6 +202,10 @@ QString Ruler::format_real_freq(uint64_t delta_index, uint64_t sample_rate)
     return format_freq(delta_period);
 }
 
+QString Ruler::format_samples(uint64_t delta_index) {
+    return QString::number(delta_index);
+}
+
 TimeMarker* Ruler::get_grabbed_cursor()
 {
     return _grabbed_marker;

--- a/DSView/pv/view/ruler.h
+++ b/DSView/pv/view/ruler.h
@@ -66,6 +66,7 @@ public:
     QString format_time(double t);
     static QString format_real_time(uint64_t delta_index, uint64_t sample_rate);
     static QString format_real_freq(uint64_t delta_index, uint64_t sample_rate);
+    static QString format_samples(uint64_t delta_index);
 
     TimeMarker* get_grabbed_cursor();
     void set_grabbed_cursor(TimeMarker* grabbed_marker);

--- a/DSView/pv/view/timemarker.h
+++ b/DSView/pv/view/timemarker.h
@@ -103,7 +103,7 @@ public:
 	 * @param prefix The SI prefix to paint time value with.
 	 */
 	virtual void paint_label(QPainter &p, const QRect &rect,
-        unsigned int prefix, bool has_hoff) = 0;
+        unsigned int prefix, bool has_hoff, bool show_samples) = 0;
 
 	inline void set_order(int order){
 		assert( order > 0);

--- a/DSView/pv/view/viewport.cpp
+++ b/DSView/pv/view/viewport.cpp
@@ -38,7 +38,8 @@
 #include <QPainterPath> 
 #include <math.h>
 #include <QWheelEvent>
- 
+#include <QScrollBar>
+
 #include "../config/appconfig.h"
 #include "../dsvdef.h"
 #include "../appcontrol.h"
@@ -1724,14 +1725,28 @@ void Viewport::paintMeasure(QPainter &p, QColor fore, QColor back)
                 Qt::AlignLeft | Qt::AlignTop, _mm_duty).width());
             typical_width = typical_width + 100;
 
-            const double width = _view.get_view_width();
-            const double height = _view.viewport()->height();
+            const double width = _view.get_view_width() - _view.verticalScrollBar()->geometry().width();
+            const double height = _view.get_view_height() - _view.horizontalScrollBar()->geometry().height() - View::StatusHeight;
             const double left = _view.hover_point().x();
             const double top = _view.hover_point().y();
             const double right = left + typical_width;
             const double bottom = top + 100;
-            QPointF org_pos = QPointF(right > width ? left - typical_width : left, bottom > height ? top - 80 : top);
-            QRectF measure_rect = QRectF(org_pos.x(), org_pos.y(), (double)typical_width, 80.0);
+            double hover_x, hover_y;
+            if(right > width) {
+                hover_x = left - typical_width - MouseEdgeClearance;
+            } else {
+                hover_x = left + MousePointerClearance;
+            }
+            if(bottom > height) {
+                hover_y = top - 100 - MousePointerClearance;
+                if(right <= width) {
+                    hover_x = left + MouseEdgeClearance;
+                }
+            } else {
+                hover_y = top + MousePointerClearance;
+            }
+            QPointF org_pos = QPointF(hover_x, hover_y);
+            QRectF measure_rect = QRectF(org_pos.x(), org_pos.y(), (double)typical_width, 100.0);
             QRectF measure1_rect = QRectF(org_pos.x(), org_pos.y(), (double)typical_width, 20.0);
             QRectF measure2_rect = QRectF(org_pos.x(), org_pos.y()+20, (double)typical_width, 20.0);
             QRectF measure3_rect = QRectF(org_pos.x(), org_pos.y()+40, (double)typical_width, 20.0);

--- a/DSView/pv/view/viewport.cpp
+++ b/DSView/pv/view/viewport.cpp
@@ -86,6 +86,7 @@ Viewport::Viewport(View &parent, View_type type) :
     _mm_period = View::Unknown_Str;
     _mm_freq = View::Unknown_Str;
     _mm_duty = View::Unknown_Str;
+    _mm_samples = View::Unknown_Str;
     _measure_en = true;
     _edge_hit = false;
     _transfer_started = false;
@@ -1574,6 +1575,7 @@ void Viewport::clear_dso_xm()
     _mm_period = View::Unknown_Str;
     _mm_freq = View::Unknown_Str;
     _mm_duty = View::Unknown_Str;
+    _mm_samples = View::Unknown_Str;
 
     set_action(NO_ACTION);
 }
@@ -1601,7 +1603,7 @@ void Viewport::measure()
                         _mm_width = _view.get_ruler()->format_real_time(_nxt_sample - _cur_sample, sample_rate);
                         _mm_period = _thd_sample != 0 ? _view.get_ruler()->format_real_time(_thd_sample - _cur_sample, sample_rate) : View::Unknown_Str;
                         _mm_freq = _thd_sample != 0 ? _view.get_ruler()->format_real_freq(_thd_sample - _cur_sample, sample_rate) : View::Unknown_Str;
-
+                        _mm_samples = _thd_sample != 0 ? _view.get_ruler()->format_samples(_thd_sample - _cur_sample) : View::Unknown_Str;
                         _cur_preX = _view.index2pixel(_cur_sample);
                         _cur_aftX = _view.index2pixel(_nxt_sample);
                         _cur_thdX = _view.index2pixel(_thd_sample);
@@ -1617,6 +1619,7 @@ void Viewport::measure()
                         _mm_period = View::Unknown_Str;
                         _mm_freq = View::Unknown_Str;
                         _mm_duty = View::Unknown_Str;
+                        _mm_samples = View::Unknown_Str;
                     }
                 }
                 else if (_action_type == LOGIC_EDGE) {
@@ -1726,27 +1729,35 @@ void Viewport::paintMeasure(QPainter &p, QColor fore, QColor back)
             const double left = _view.hover_point().x();
             const double top = _view.hover_point().y();
             const double right = left + typical_width;
-            const double bottom = top + 80;
+            const double bottom = top + 100;
             QPointF org_pos = QPointF(right > width ? left - typical_width : left, bottom > height ? top - 80 : top);
             QRectF measure_rect = QRectF(org_pos.x(), org_pos.y(), (double)typical_width, 80.0);
             QRectF measure1_rect = QRectF(org_pos.x(), org_pos.y(), (double)typical_width, 20.0);
             QRectF measure2_rect = QRectF(org_pos.x(), org_pos.y()+20, (double)typical_width, 20.0);
             QRectF measure3_rect = QRectF(org_pos.x(), org_pos.y()+40, (double)typical_width, 20.0);
             QRectF measure4_rect = QRectF(org_pos.x(), org_pos.y()+60, (double)typical_width, 20.0);
+            QRectF measure5_rect = QRectF(org_pos.x(), org_pos.y()+80, (double)typical_width, 20.0);
 
             p.setPen(Qt::NoPen);
             p.setBrush(View::LightBlue);
             p.drawRect(measure_rect);
 
             p.setPen(active_color);
-            p.drawText(measure1_rect, Qt::AlignRight | Qt::AlignVCenter,
-                       L_S(STR_PAGE_DLG, S_ID(IDS_DLG_WIDTH), "Width: ") + _mm_width);
-            p.drawText(measure2_rect, Qt::AlignRight | Qt::AlignVCenter,
-                       L_S(STR_PAGE_DLG, S_ID(IDS_DLG_PERIOD), "Period: ") + _mm_period);
-            p.drawText(measure3_rect, Qt::AlignRight | Qt::AlignVCenter,
-                       L_S(STR_PAGE_DLG, S_ID(IDS_DLG_FREQUENCY), "Frequency: ") + _mm_freq);
-            p.drawText(measure4_rect, Qt::AlignRight | Qt::AlignVCenter,
-                      L_S(STR_PAGE_DLG, S_ID(IDS_DLG_DUTY_CYCLE), "Duty Cycle: ") + _mm_duty);
+            p.drawText(measure1_rect, Qt::AlignLeft | Qt::AlignVCenter,
+                       L_S(STR_PAGE_DLG, S_ID(IDS_DLG_WIDTH), "Width: "));
+            p.drawText(measure1_rect, Qt::AlignRight | Qt::AlignVCenter,_mm_width);
+            p.drawText(measure2_rect, Qt::AlignLeft | Qt::AlignVCenter,
+                       L_S(STR_PAGE_DLG, S_ID(IDS_DLG_PERIOD), "Period: "));
+            p.drawText(measure2_rect, Qt::AlignRight | Qt::AlignVCenter, _mm_period);
+            p.drawText(measure3_rect, Qt::AlignLeft | Qt::AlignVCenter,
+                       L_S(STR_PAGE_DLG, S_ID(IDS_DLG_FREQUENCY), "Frequency: "));
+            p.drawText(measure3_rect, Qt::AlignRight | Qt::AlignVCenter, _mm_freq);
+            p.drawText(measure4_rect, Qt::AlignLeft | Qt::AlignVCenter,
+                      L_S(STR_PAGE_DLG, S_ID(IDS_DLG_DUTY_CYCLE), "Duty Cycle: "));
+            p.drawText(measure4_rect, Qt::AlignRight | Qt::AlignVCenter, _mm_duty);
+            p.drawText(measure5_rect, Qt::AlignLeft | Qt::AlignVCenter,
+                      L_S(STR_PAGE_DLG, S_ID(IDS_DLG_SAMPLES_MEAS), "Samples: "));
+            p.drawText(measure5_rect, Qt::AlignRight | Qt::AlignCenter, _mm_samples);
         }
     } 
 
@@ -2017,6 +2028,8 @@ QString Viewport::get_measure(QString option)
         return _mm_freq;
     else if (option.compare("duty") == 0)
         return _mm_duty;
+    else if (option.compare("samples") == 0)
+        return _mm_samples;
     else
         return View::Unknown_Str;
 }

--- a/DSView/pv/view/viewport.h
+++ b/DSView/pv/view/viewport.h
@@ -77,6 +77,8 @@ public:
     static const double DragDamping;
     static const int SnapMinSpace = 10;
     static const int WaitLoopTime = 400;
+    static const int MousePointerClearance = 25;
+    static const int MouseEdgeClearance = 3;
     enum ActionType {
         NO_ACTION,
 

--- a/DSView/pv/view/viewport.h
+++ b/DSView/pv/view/viewport.h
@@ -201,6 +201,7 @@ private:
     QString     _mm_period;
     QString     _mm_freq;
     QString     _mm_duty;
+    QString     _mm_samples;
 
     uint64_t    _edge_rising;
     uint64_t    _edge_falling;

--- a/lang/cn/dlg.json
+++ b/lang/cn/dlg.json
@@ -628,6 +628,18 @@
         "text": "占空比: "
     },
     {
+        "id": "IDS_DLG_SAMPLES_MEAS",
+        "text": "采样点个数: "
+    },
+    {
+        "id": "IDS_DLG_TIME",
+        "text": "时间"
+    },
+    {
+        "id": "IDS_DLG_SAMPLES",
+        "text": "采样点个数"
+    },
+    {
         "id": "IDS_DLG_MEASURE",
         "text": "测量"
     },

--- a/lang/en/dlg.json
+++ b/lang/en/dlg.json
@@ -628,6 +628,22 @@
         "text": "Duty Cycle: "
     },
     {
+        "id": "IDS_DLG_SAMPLES_MEAS",
+        "text": "Samples: "
+    },
+    {
+        "id": "IDS_DLG_SAMPLES",
+        "text": "Samples"
+    },
+    {
+        "id": "IDS_DLG_TIME",
+        "text": "Time"
+    },
+    {
+        "id": "IDS_DLG_RULER_UNITS",
+        "text": "Ruler / Cursor units"
+    },
+    {
         "id": "IDS_DLG_MEASURE",
         "text": "Measure"
     },


### PR DESCRIPTION
1. **Add support for sample display in cursor labels and ruler**
   - Enhanced the ruler and cursors to display sample counts, switchable via Display configuration.
   - Improved stability of the ruler to avoid flickering between scales.

2. **Improve measurement hover position for visibility**
   - Adjustments to take into account scroll bars and status bar.
   - Added clearance to keep the trace visible and steer clear of the mouse pointer.

3. **Add samples display to Measurement Dock and hover overlay**
   - Measurement Dock now includes display of sample counts.

4. **Add ruler time unit configuration and UI binding**
   - Added configuration for ruler/cursor time units and bound it to the UI.
   - TODO: IDS_DLG_RULER_UNITS ("Ruler / Cursor units") is missing for Chinese localization.