### PR TITLE
Vertical scrolling shortcuts in Viewport

### DIFF
--- a/DSView/pv/dock/protocoldock.cpp
+++ b/DSView/pv/dock/protocoldock.cpp
@@ -623,7 +623,7 @@ void ProtocolDock::nav_table_view()
 
     auto decoder_stack = decoder_model->getDecoderStack();
     if (decoder_stack) {
-        uint64_t offset = _view.offset() * (decoder_stack->samplerate() * _view.scale());
+        uint64_t offset = _view.x_offset() * (decoder_stack->samplerate() * _view.scale());
         std::map<const pv::data::decode::Row, bool> rows = decoder_stack->get_rows_lshow();
         int column = _model_proxy.filterKeyColumn();
         for (std::map<const pv::data::decode::Row, bool>::const_iterator i = rows.begin();

--- a/DSView/pv/mainwindow.cpp
+++ b/DSView/pv/mainwindow.cpp
@@ -1280,14 +1280,14 @@ namespace pv
             case 33:
 #endif
                 _view->set_scale_offset(_view->scale(),
-                                        _view->offset() - _view->get_view_width());
+                                        _view->x_offset() - _view->get_view_width());
                 break;
             case Qt::Key_PageDown:
 #ifdef _WIN32
             case 34:
 #endif
                 _view->set_scale_offset(_view->scale(),
-                                        _view->offset() + _view->get_view_width());
+                                        _view->x_offset() + _view->get_view_width());
 
                 break;
 

--- a/DSView/pv/view/analogsignal.cpp
+++ b/DSView/pv/view/analogsignal.cpp
@@ -161,7 +161,7 @@ bool AnalogSignal::measure(const QPointF &p)
 
     const double scale = _view->scale();
     assert(scale > 0);
-    const int64_t pixels_offset = _view->offset();
+    const int64_t pixels_offset = _view->x_offset();
     const double samplerate = _view->session().cur_snap_samplerate();
     const double samples_per_pixel = samplerate * scale;
 
@@ -198,7 +198,7 @@ QPointF AnalogSignal::get_point(uint64_t index, float &value)
 
     const double scale = _view->scale();
     assert(scale > 0);
-    const int64_t pixels_offset = _view->offset();
+    const int64_t pixels_offset = _view->x_offset();
     const double samplerate = _view->session().cur_snap_samplerate();
     const double samples_per_pixel = samplerate * scale;
 
@@ -410,7 +410,7 @@ void AnalogSignal::paint_mid(QPainter &p, int left, int right, QColor fore, QCol
     const double scale = _view->scale();
 
     assert(scale > 0);
-    const int64_t offset = _view->offset();
+    const int64_t offset = _view->x_offset();
 
     const int order = _data->get_ch_order(get_index());
     if (order == -1)

--- a/DSView/pv/view/cursor.cpp
+++ b/DSView/pv/view/cursor.cpp
@@ -56,8 +56,8 @@ QRect Cursor::get_label_rect(const QRect &rect, bool &visible, bool has_hoff)
 {
     const double samples_per_pixel = _view.session().cur_snap_samplerate() * _view.scale();
     const double cur_offset = _index / samples_per_pixel;
-    if (cur_offset < _view.offset() ||
-        cur_offset > (_view.offset() + _view.width())) {
+    if (cur_offset < _view.x_offset() ||
+        cur_offset > (_view.x_offset() + _view.width())) {
         visible = false;
         return QRect(-1, -1, 0, 0);
     }

--- a/DSView/pv/view/decodetrace.cpp
+++ b/DSView/pv/view/decodetrace.cpp
@@ -196,8 +196,8 @@ void DecodeTrace::paint_back(QPainter &p, int left, int right, QColor fore, QCol
 
     // --draw decode region control
     const double samples_per_pixel = _session->cur_snap_samplerate() * _view->scale();
-    const double startX = _decode_start/samples_per_pixel - _view->offset();
-    const double endX = _decode_end/samples_per_pixel - _view->offset();
+    const double startX = _decode_start/samples_per_pixel - _view->x_offset();
+    const double endX = _decode_end/samples_per_pixel - _view->x_offset();
     const double regionY = get_y() - _totalHeight*0.5 - ControlRectWidth;
 
     p.setBrush(View::Blue);
@@ -265,7 +265,7 @@ void DecodeTrace::paint_mid(QPainter &p, int left, int right, QColor fore, QColo
     if (samplerate == 0.0)
         samplerate = 1.0;
 
-    const int64_t pixels_offset = _view->offset();
+    const int64_t pixels_offset = _view->x_offset();
     const double samples_per_pixel = samplerate * scale;
 
     uint64_t start_sample = (uint64_t)max((left + pixels_offset) *

--- a/DSView/pv/view/dsosignal.cpp
+++ b/DSView/pv/view/dsosignal.cpp
@@ -715,7 +715,7 @@ void DsoSignal::paint_back(QPainter &p, int left, int right, QColor fore, QColor
     const double samplerate = session->cur_snap_samplerate();
     const double samples_per_pixel = samplerate * _view->scale();
     const double shown_rate = min(samples_per_pixel * width * 1.0 / sample_len, 1.0);
-    const double start = _view->offset() * samples_per_pixel;
+    const double start = _view->x_offset() * samples_per_pixel;
     const double shown_offset = min(start / sample_len, 1.0) * width;
     const double shown_len = max(shown_rate * width, 6.0);
     const QPointF left_edge[] =  {QPoint(shown_offset + 3, UpMargin/2 - 6),
@@ -782,7 +782,7 @@ void DsoSignal::paint_mid(QPainter &p, int left, int right, QColor fore, QColor 
 
         const double scale = _view->scale();
         assert(scale > 0);
-        const int64_t offset = _view->offset();
+        const int64_t offset = _view->x_offset();
 
         if (_data->empty() || !_data->has_data(index))
             return;

--- a/DSView/pv/view/logicsignal.cpp
+++ b/DSView/pv/view/logicsignal.cpp
@@ -118,7 +118,7 @@ void LogicSignal::paint_mid_align(QPainter &p, int left, int right, QColor fore,
     const int y = get_y() + _totalHeight * 0.5;
     const double scale = _view->scale();
     assert(scale > 0);
-    const int64_t offset = _view->offset();
+    const int64_t offset = _view->x_offset();
 
     const int high_offset = y - _totalHeight + 0.5f;
     const int low_offset = y + 0.5f;
@@ -297,7 +297,7 @@ bool LogicSignal::measure(const QPointF &p, uint64_t &index0, uint64_t &index1, 
             return false;
 
         const uint64_t end = _data->get_ring_sample_count() - 1;
-        uint64_t index = _data->samplerate() * _view->scale() * (_view->offset() + p.x());
+        uint64_t index = _data->samplerate() * _view->scale() * (_view->x_offset() + p.x());
         
         if (index > end){
             return false;
@@ -350,7 +350,7 @@ bool LogicSignal::is_by_edge(const QPointF &p, uint64_t &index, int radius)
             return false;
 
         const uint64_t end = _data->get_ring_sample_count() - 1;
-        const double pos = _data->samplerate() * _view->scale() * (_view->offset() + p.x());
+        const double pos = _data->samplerate() * _view->scale() * (_view->x_offset() + p.x());
         index = floor(pos + 0.5);
         if (index > end)
             return false;
@@ -403,7 +403,7 @@ bool LogicSignal::edge(const QPointF &p, uint64_t &index, int radius)
             return false;
 
         const uint64_t end = _data->get_ring_sample_count() - 1;
-        const double pos = _data->samplerate() * _view->scale() * (_view->offset() + p.x());
+        const double pos = _data->samplerate() * _view->scale() * (_view->x_offset() + p.x());
         index = floor(pos + 0.5);
         if (index > end)
             return false;
@@ -445,7 +445,7 @@ bool LogicSignal::edges(const QPointF &p, uint64_t start, uint64_t &rising, uint
     uint64_t end;
     const float gap = abs(p.y() - get_y());
     if (gap < get_totalHeight() * 0.5) {
-        end = _data->samplerate() * _view->scale() * (_view->offset() + p.x());
+        end = _data->samplerate() * _view->scale() * (_view->x_offset() + p.x());
         return edges(end, start, rising, falling);
     }
     return false;

--- a/DSView/pv/view/mathtrace.cpp
+++ b/DSView/pv/view/mathtrace.cpp
@@ -217,7 +217,7 @@ void MathTrace::paint_mid(QPainter &p, int left, int right, QColor fore, QColor 
 
         const double scale = _view->scale();
         assert(scale > 0);
-        const int64_t offset = _view->offset();
+        const int64_t offset = _view->x_offset();
 
         const double pixels_offset = offset;
         //const double samplerate = _view->session().cur_snap_samplerate();

--- a/DSView/pv/view/ruler.cpp
+++ b/DSView/pv/view/ruler.cpp
@@ -446,7 +446,7 @@ void Ruler::draw_logic_tick_mark(QPainter &p)
     double typical_width;
     double tick_period = 0;
     double scale = _view.scale();
-    int64_t offset = _view.offset();
+    int64_t offset = _view.x_offset();
 
     const uint64_t cur_period_scale = ceil((scale * min_width) / abs_min_period);
 

--- a/DSView/pv/view/view.cpp
+++ b/DSView/pv/view/view.cpp
@@ -87,6 +87,7 @@ View::View(SigSession *session, pv::toolbars::SamplingBar *sampling_bar, QWidget
     _maxscale(1e9),
     _minscale(1e-15),
 	_x_offset(0),
+    _y_offset(0),
     _preOffset(0),
 	_updating_scroll(false),
     _trig_hoff(0),
@@ -985,6 +986,9 @@ void View::h_scroll_value_changed(int value)
 
 void View::v_scroll_value_changed(int value)
 {
+    // Track vertical offset
+    _y_offset = value;
+
     // Update vertical positions of all traces based on scroll value
     std::vector<Trace*> traces;
     get_traces(ALL_VIEW, traces);

--- a/DSView/pv/view/view.h
+++ b/DSView/pv/view/view.h
@@ -141,6 +141,13 @@ public:
     }
 
 	/**
+     * Returns the pixels offset of the top edge of the view
+	 */
+    inline int64_t y_offset(){
+        return _y_offset;
+    }
+
+    /**
      * trigger position fix
      */
     inline double trig_hoff(){
@@ -456,6 +463,7 @@ private:
 
     /// The pixels offset of the left edge of the view
     int64_t     _x_offset;
+    int64_t     _y_offset;
     int64_t     _preOffset;
     int         _spanY;
     int         _signalHeight;

--- a/DSView/pv/view/view.h
+++ b/DSView/pv/view/view.h
@@ -136,11 +136,11 @@ public:
 	/**
      * Returns the pixels offset of the left edge of the view
 	 */
-    inline int64_t offset(){
-        return _offset;
+    inline int64_t x_offset(){
+        return _x_offset;
     }
 
-    /**
+	/**
      * trigger position fix
      */
     inline double trig_hoff(){
@@ -455,7 +455,7 @@ private:
     double      _minscale;
 
     /// The pixels offset of the left edge of the view
-    int64_t     _offset;
+    int64_t     _x_offset;
     int64_t     _preOffset;
     int         _spanY;
     int         _signalHeight;

--- a/DSView/pv/view/viewport.cpp
+++ b/DSView/pv/view/viewport.cpp
@@ -644,7 +644,7 @@ void Viewport::mousePressEvent(QMouseEvent *event)
 	assert(event);
     
 	_mouse_down_point = event->pos();
-	_mouse_down_offset = _view.x_offset();
+	_mouse_down_offset = QPoint(_view.x_offset(), _view.y_offset());
     _drag_strength = 0;
     _elapsed_time.restart();
 
@@ -796,7 +796,7 @@ void Viewport:: mouseMoveEvent(QMouseEvent *event)
     if (event->buttons() & Qt::LeftButton) {
         if (_type == TIME_VIEW) {
             if (_action_type == NO_ACTION) {
-                int64_t x = _mouse_down_offset + (_mouse_down_point - event->pos()).x();
+                int64_t x = _mouse_down_offset.x() + (_mouse_down_point - event->pos()).x();
                 _view.set_scale_offset(_view.scale(), x);
             }
             _drag_strength = (_mouse_down_point - event->pos()).x();
@@ -809,6 +809,12 @@ void Viewport:: mouseMoveEvent(QMouseEvent *event)
                     break;
                 }
             }
+        }
+    }
+
+    if (event->buttons() & Qt::MiddleButton) {
+        if (_action_type == NO_ACTION) {
+            _view.verticalScrollBar()->setValue(_mouse_down_offset.y() + _mouse_down_point.y() - event->pos().y());
         }
     }
 
@@ -1407,7 +1413,11 @@ void Viewport::wheelEvent(QWheelEvent *event)
                 _view.zoom(-zoom_scale, x);
             }
 #else
+        if(event->modifiers() & Qt::ControlModifier) {
+            _view.verticalScrollBar()->setValue(_view.verticalScrollBar()->value() - delta);
+        } else {
             _view.zoom(zoom_scale, x);
+        }
 #endif
         }
         else

--- a/DSView/pv/view/viewport.cpp
+++ b/DSView/pv/view/viewport.cpp
@@ -294,11 +294,11 @@ void Viewport::paintSignals(QPainter &p, QColor fore, QColor back)
     } 
     else {
         if (_view.scale() != _curScale ||
-            _view.offset() != _curOffset ||
+            _view.x_offset() != _curOffset ||
             _view.get_signalHeight() != _curSignalHeight ||
             _need_update) {
             _curScale = _view.scale();
-            _curOffset = _view.offset();
+            _curOffset = _view.x_offset();
             _curSignalHeight = _view.get_signalHeight();
 
             _pixmap = QPixmap(size());
@@ -644,7 +644,7 @@ void Viewport::mousePressEvent(QMouseEvent *event)
 	assert(event);
     
 	_mouse_down_point = event->pos();
-	_mouse_down_offset = _view.offset();
+	_mouse_down_offset = _view.x_offset();
     _drag_strength = 0;
     _elapsed_time.restart();
 
@@ -1076,7 +1076,7 @@ void Viewport::onLogicMouseRelease(QMouseEvent *event)
         case LOGIC_ZOOM:
         {
             if (event->pos().x() != _mouse_down_point.x()) {
-                int64_t newOffset = _view.offset() + (min(event->pos().x(), _mouse_down_point.x()));
+                int64_t newOffset = _view.x_offset() + (min(event->pos().x(), _mouse_down_point.x()));
                 const double newScale = max(min(_view.scale() * abs(event->pos().x() - _mouse_down_point.x()) / _view.get_view_width(),
                                                 _view.get_maxscale()), _view.get_minscale());
                 newOffset = floor(newOffset * (_view.scale() / newScale));
@@ -1417,7 +1417,7 @@ void Viewport::wheelEvent(QWheelEvent *event)
 
             // Horizontal scrolling is interpreted as moving left/right
             if (!(event->modifiers() & Qt::ShiftModifier))
-                _view.set_scale_offset(_view.scale(), _view.offset() - delta);
+                _view.set_scale_offset(_view.scale(), _view.x_offset() - delta);
         }
     }
 
@@ -2097,7 +2097,7 @@ void Viewport::on_trigger_timer()
 
 void Viewport::on_drag_timer()
 {   
-    const int64_t offset = _view.offset();
+    const int64_t offset = _view.x_offset();
     const double scale = _view.scale();
 
     if (_view.session().is_stopped_status()

--- a/DSView/pv/view/viewport.h
+++ b/DSView/pv/view/viewport.h
@@ -179,7 +179,7 @@ private:
     uint64_t    _sample_received;
     QPoint      _mouse_point;
     QPoint      _mouse_down_point;
-    int64_t     _mouse_down_offset;
+    QPoint      _mouse_down_offset;
     double      _curScale;
     int64_t     _curOffset;
     int         _curSignalHeight;


### PR DESCRIPTION
This enables vertical scrolling without having to click the vertical scroll bar.

View::_offset is renamed to x_offset. y_offset is introduced for vertical tracking of the viewport.
The Viewport can be scrolled vertically by dragging using the middle mouse button or Ctrl+mouse wheel.
