### PR TITLE
Improve swipe scrolling usability for Logic waveform view

### DIFF
--- a/DSView/pv/view/viewport.cpp
+++ b/DSView/pv/view/viewport.cpp
@@ -648,6 +648,11 @@ void Viewport::mousePressEvent(QMouseEvent *event)
     _drag_strength = 0;
     _elapsed_time.restart();
 
+    // cancel potential ongoing MOVE action so click/drag is evaluated anew
+    if (_action_type == LOGIC_MOVE) {
+        set_action(NO_ACTION);
+    }
+
     if (_action_type == NO_ACTION
         && event->button() == Qt::RightButton
         && _view.session().is_stopped_status())
@@ -1092,6 +1097,9 @@ void Viewport::onLogicMouseRelease(QMouseEvent *event)
             set_action(NO_ACTION);
             break;
         }
+        case LOGIC_MOVE:
+        default:
+            break;
     } 
 }
 
@@ -1484,9 +1492,7 @@ void Viewport::leaveEvent(QEvent *)
         set_action(NO_ACTION);
     }
     else if (_action_type == LOGIC_MOVE) {
-        _drag_strength = 0;
-        _drag_timer.stop();
-        set_action(NO_ACTION);
+        // continue swipe scrolling even when mouse leaves viewport
     }
     else if (_action_type == DSO_XM_STEP1 || _action_type == DSO_XM_STEP2) {
         clear_dso_xm();

--- a/DSView/pv/view/viewport.h
+++ b/DSView/pv/view/viewport.h
@@ -70,7 +70,7 @@ class Viewport : public QWidget, public IUiWindow
 public:
     static const int HitCursorMargin = 10;
     static const double HitCursorTimeMargin;
-    static const int DragTimerInterval = 100;
+    static const int DragTimerInterval = 8;
     static const int MinorDragOffsetUp = 100;
     static const int DsoMeasureStages = 3;
     static const double MinorDragRateUp;

--- a/DSView/pv/view/viewport.h
+++ b/DSView/pv/view/viewport.h
@@ -71,6 +71,7 @@ public:
     static const int HitCursorMargin = 10;
     static const double HitCursorTimeMargin;
     static const int DragTimerInterval = 8;
+    static const int DragVelocityMeasureIntervalMs = 10;
     static const int MinorDragOffsetUp = 100;
     static const int DsoMeasureStages = 3;
     static const double MinorDragRateUp;
@@ -157,6 +158,8 @@ private:
     void onDsoMouseRelease(QMouseEvent *event);
     void onAnalogMouseRelease(QMouseEvent *event);
 
+    void updateDragVelocity(QMouseEvent *event);
+
 private slots:
     void on_trigger_timer();
     void on_drag_timer();
@@ -225,7 +228,11 @@ private:
 
     QElapsedTimer   _elapsed_time;
     QTimer          _drag_timer;
-    int             _drag_strength;
+    QPoint          _drag_last_mouse_pos;
+    qint64          _drag_delta_t;  // cumulative time during dragging (for measuring velocity)
+    int             _drag_delta_x;  // cumulative x movement per interval during dragging
+    double          _drag_velocity; // pixels per interval (DragVelocityMeasureIntervalMs)
+    int             _drag_strength; // resulting initial swipe velocity (pixels per DragTimerIntervalMs)
     bool            _dso_xm_valid;
     int             _dso_xm_y;
     uint64_t        _dso_xm_index[DsoMeasureStages];


### PR DESCRIPTION
The prior swipe implementation has some issues:
* The entire click/touch-drag-release gesture must be completed within 0.2s; this alone makes it nearly impossible to do a well-controlled swipe movement
* Swipe distance must be at least 25% of the view width, or 40% of the view width if the window is maximized
* Swipe velocity is calculated based on the total horizontal difference between click/touch and release so it is impractical to drag around left and right a bit, then finally "throw" the view in any direction
* Even when stopping before release, swiping might happen due to the total travel calculation method.
* View update rate is very low (10Hz / 100ms) making the effect feel unnatural / unintended.
* Scrolling stops immediately when the mouse leaves the waveform display

To improve on this behaviour the following measures are applied:
* Swipe velocity is calculated based on pixels per time period (currently 10ms) *close to the time of release* so it is immediately related to the actual mouse/finger movement
* Maximum gesture time and distance constraints are removed, they are obsolete due to the more direct velocity calculation
* Mouse leaving or entering the waveform display will not stop scrolling
* View update rate is increased to about 120Hz (8ms)
